### PR TITLE
Actor type is now written out to each document stored in DynamoDB

### DIFF
--- a/src/main/java/cloud/orbit/actors/extensions/dynamodb/DynamoDBStorageExtension.java
+++ b/src/main/java/cloud/orbit/actors/extensions/dynamodb/DynamoDBStorageExtension.java
@@ -127,7 +127,8 @@ public class DynamoDBStorageExtension implements StorageExtension
             final ObjectMapper mapper = dynamoDBConnection.getMapper();
             final String serializedState = mapper.writeValueAsString(state);
 
-            final String tableName = getTableName(RemoteReference.getInterfaceClass(reference), state.getClass());
+            final Class<?> referenceType = RemoteReference.getInterfaceClass(reference);
+            final String tableName = getTableName(referenceType, state.getClass());
             final String itemId = generateDocumentId(reference, state);
 
             return DynamoDBUtils.getTable(dynamoDBConnection, tableName)
@@ -135,6 +136,7 @@ public class DynamoDBStorageExtension implements StorageExtension
                     {
                         final Item newItem = new Item()
                                 .withPrimaryKey(DynamoDBUtils.FIELD_NAME_PRIMARY_ID, itemId)
+                                .with(DynamoDBUtils.FIELD_NAME_OWNING_ACTOR_TYPE, referenceType.getName())
                                 .withJSON(DynamoDBUtils.FIELD_NAME_DATA, serializedState);
 
                         table.putItem(newItem);

--- a/src/main/java/cloud/orbit/actors/extensions/dynamodb/DynamoDBUtils.java
+++ b/src/main/java/cloud/orbit/actors/extensions/dynamodb/DynamoDBUtils.java
@@ -56,6 +56,7 @@ public class DynamoDBUtils
     final static long WAITING_FOR_ACTIVE_TABLE_STATUS_RETRY_DELAY_MILLIS = 600;
     final static public String FIELD_NAME_PRIMARY_ID = "_id";
     final static public String FIELD_NAME_DATA = "_state";
+    final static public String FIELD_NAME_OWNING_ACTOR_TYPE = "_owningType";
 
     private static ConcurrentMap<String, Table> tableCache = new ConcurrentHashMap<>();
 


### PR DESCRIPTION
This also addresses an intermittent test failure where record count checks would fail because a document of an unexpected type (ReminderController) was in the table.
